### PR TITLE
Compliance with Coding Style Conventions

### DIFF
--- a/Api/Modules/Shared/ApiClient/Services/ApiClientService.cs
+++ b/Api/Modules/Shared/ApiClient/Services/ApiClientService.cs
@@ -5,31 +5,31 @@ namespace Api.Modules.Shared.ApiClient.Services;
 
 internal sealed class ApiClientService : IDisposable
 {
-    private readonly HttpClient _HttpClient;
+    private readonly HttpClient _httpClient;
 
-    private readonly string _ApiPath;
+    private readonly string _apiPath;
+
+    private static readonly JsonSerializerOptions s_defaultSerializationOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
     public ApiClientService(HttpClient httpClient, IConfiguration configuration)
     {
-        _HttpClient = httpClient;
-        _HttpClient.BaseAddress = new Uri(configuration.GetStringValueOrThrowUnreachable("LtoApi:Server"));
-        _ApiPath = configuration.GetStringValueOrThrowUnreachable("LtoApi:Path");
+        _httpClient = httpClient;
+        _httpClient.BaseAddress = new Uri(configuration.GetStringValueOrThrowUnreachable("LtoApi:Server"));
+        _apiPath = configuration.GetStringValueOrThrowUnreachable("LtoApi:Path");
     }
 
     public async Task<TResponse> PostAsync<TResponse, TRequest>(TRequest body, string endpoint) =>
-        await (await _HttpClient.PostAsJsonAsync($"{_ApiPath}/{endpoint}", body, _DefaultSerializationOptions)).Content.ReadFromJsonAsync<TResponse>() ?? throw new NullReferenceException();
+        await (await _httpClient.PostAsJsonAsync($"{_apiPath}/{endpoint}", body, s_defaultSerializationOptions)).Content.ReadFromJsonAsync<TResponse>() ?? throw new NullReferenceException();
 
     public async Task<TResponse> GetAsync<TResponse>(string endpoint) =>
-        await _HttpClient.GetFromJsonAsync<TResponse>($"{_ApiPath}/{endpoint}", _DefaultSerializationOptions) ?? throw new NullReferenceException();
+        await _httpClient.GetFromJsonAsync<TResponse>($"{_apiPath}/{endpoint}", s_defaultSerializationOptions) ?? throw new NullReferenceException();
 
-    public void Dispose() => _HttpClient?.Dispose();
+    public void Dispose() => _httpClient?.Dispose();
 
     public ApiClientService SetAccessToken(string token)
     {
-        _HttpClient.DefaultRequestHeaders.Add("Access_token", token);
+        _httpClient.DefaultRequestHeaders.Add("Access_token", token);
         // Return this instance to allow for chaining.
         return this;
     }
-
-    private static JsonSerializerOptions _DefaultSerializationOptions { get => new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }; }
 }


### PR DESCRIPTION
- Applied C# identifier naming conventions to the ApiClientService class to comply with Microsoft's guidelines.