### PR TITLE
feat(profiles): add GetProfiles endpoint and models

### DIFF
--- a/Api/Modules/Profiles/Core/AlarmDetails.cs
+++ b/Api/Modules/Profiles/Core/AlarmDetails.cs
@@ -1,0 +1,9 @@
+namespace Api.Modules.Profiles.Core;
+
+internal sealed record AlarmDetails(
+    bool IsUpper,
+    double? ThresholdValue,
+    int NumberOfReadingsBeforeAlert,
+    string AlarmTriggerType,
+    string Sensor
+);

--- a/Api/Modules/Profiles/Core/GetProfilesResponse.cs
+++ b/Api/Modules/Profiles/Core/GetProfilesResponse.cs
@@ -1,0 +1,12 @@
+namespace Api.Modules.Profiles.Core;
+
+internal sealed record GetProfilesResponse(
+    int Id,
+    string Name,
+    string Model,
+    int RecordingIntervalInSeconds,
+    int StartDelayInSeconds,
+    bool? AlarmIndicatorEnabled,
+    bool? AllowLoggingStop,
+    List<AlarmDetails> Alarms
+);

--- a/Api/Modules/Profiles/Endpoints/GetProfiles.cs
+++ b/Api/Modules/Profiles/Endpoints/GetProfiles.cs
@@ -1,0 +1,13 @@
+using Api.Modules.Profiles.Core;
+using Api.Modules.Shared.ApiClient.Services;
+using Api.Modules.Shared.Core;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Modules.Profiles.Endpoints;
+
+internal static class GetProfiles
+{
+    public static async Task<Ok<ResponseWithPayload<GetProfilesResponse>>> Handler([FromServices] ApiClientService apiClient, [FromBody] RequestWithToken vm) =>
+        TypedResults.Ok(value: await apiClient.SetAccessToken(vm.Token).GetAsync<ResponseWithPayload<GetProfilesResponse>>($"profiles/v1/{vm.TeamId}"));
+}

--- a/Api/Modules/Profiles/ProfilesModule.cs
+++ b/Api/Modules/Profiles/ProfilesModule.cs
@@ -1,0 +1,14 @@
+using Api.Modules.Profiles.Endpoints;
+using Module.Interfaces;
+
+internal sealed class ProfilesModule : IEndpointModule
+{
+    public IEndpointRouteBuilder MapEndpoints(IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/ProfilesApi").WithTags("ProfilesModule");
+
+        group.MapPost("/GetProfiles", GetProfiles.Handler).WithOpenApi();
+
+        return group;
+    }
+}


### PR DESCRIPTION
cb96e5dd1eea619b81092e74f182d5636a067d78

- Added a new namespace `Api.Modules.Profiles.Core` and defined a sealed record `AlarmDetails` with properties `IsUpper`, `ThresholdValue`, `NumberOfReadingsBeforeAlert`, `AlarmTriggerType`, and `Sensor`.
- Defined a sealed record `GetProfilesResponse` with properties `Id`, `Name`, `Model`, `RecordingIntervalInSeconds`, `StartDelayInSeconds`, `AlarmIndicatorEnabled`, `AllowLoggingStop`, and a list of `AlarmDetails` named `Alarms`.
- Added a new namespace `Api.Modules.Profiles.Endpoints` and defined a static class `GetProfiles` with an asynchronous method `Handler` that handles HTTP POST requests. This method uses `ApiClientService` to fetch profile data and returns it wrapped in an `Ok` result.
- Updated `ProfilesModule` to include the new `GetProfiles` endpoint. This class implements `IEndpointModule` and maps the `/GetProfiles` route to the `GetProfiles.Handler` method, adding it to the `/ProfilesApi` group with the tag `ProfilesModule`.